### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -85,11 +85,11 @@ end
 # => Git segment
 ################
 function __dangerous_is_git_ahead_or_behind -d 'Check if there are unpulled or unpushed commits'
-    command git rev-list --count --left-right 'HEAD...@{upstream}' ^ /dev/null  | sed 's|\s\+|\n|g'
+    command git rev-list --count --left-right 'HEAD...@{upstream}' 2> /dev/null  | sed 's|\s\+|\n|g'
 end
 
 function __dangerous_git_status -d 'Check git status'
-    set -l git_status (command git status --porcelain ^/dev/null | cut -c 1-2)
+    set -l git_status (command git status --porcelain 2> /dev/null | cut -c 1-2)
     set -l added (echo -sn $git_status\n | egrep -c "[ACDMT][ MT]|[ACMT]D")
     set -l deleted (echo -sn $git_status\n | egrep -c "[ ACMRT]D")
     set -l modified (echo -sn $git_status\n | egrep -c ".[MT]")
@@ -100,11 +100,11 @@ function __dangerous_git_status -d 'Check git status'
 end
 
 function __dangerous_is_git_stashed -d 'Check if there are stashed commits'
-    command git log --format="%gd" -g $argv 'refs/stash' -- ^ /dev/null | wc -l | tr -d '[:space:]'
+    command git log --format="%gd" -g $argv 'refs/stash' -- 2> /dev/null | wc -l | tr -d '[:space:]'
 end
 
 function __dangerous_prompt_git_symbols -d 'Displays the git symbols'
-    set -l is_repo (command git rev-parse --is-inside-work-tree ^/dev/null)
+    set -l is_repo (command git rev-parse --is-inside-work-tree 2> /dev/null)
     if [ -z $is_repo ]
         return
     end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618