### PR TITLE
change from egrep to grep (warning about obsolescence)

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -90,12 +90,12 @@ end
 
 function __dangerous_git_status -d 'Check git status'
     set -l git_status (command git status --porcelain 2> /dev/null | cut -c 1-2)
-    set -l added (echo -sn $git_status\n | egrep -c "[ACDMT][ MT]|[ACMT]D")
-    set -l deleted (echo -sn $git_status\n | egrep -c "[ ACMRT]D")
-    set -l modified (echo -sn $git_status\n | egrep -c ".[MT]")
-    set -l renamed (echo -sn $git_status\n | egrep -c "R.")
-    set -l unmerged (echo -sn $git_status\n | egrep -c "AA|DD|U.|.U")
-    set -l untracked (echo -sn $git_status\n | egrep -c "\?\?")
+    set -l added (echo -sn $git_status\n | grep -c -E "[ACDMT][ MT]|[ACMT]D")
+    set -l deleted (echo -sn $git_status\n | grep -c -E "[ ACMRT]D")
+    set -l modified (echo -sn $git_status\n | grep -c -E ".[MT]")
+    set -l renamed (echo -sn $git_status\n | grep -c -E "R.")
+    set -l unmerged (echo -sn $git_status\n | grep -c -E "AA|DD|U.|.U")
+    set -l untracked (echo -sn $git_status\n | grep -c -E "\?\?")
     echo -n $added\n$deleted\n$modified\n$renamed\n$unmerged\n$untracked
 end
 


### PR DESCRIPTION
Small change made to remove this warning when using dangerous theme:

egrep: warning: egrep is obsolescent; using grep -E